### PR TITLE
Cd/pro 233 display pcrs nicely in repo

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Ensure rustfmt is available
         run: rustup component add rustfmt
 
-      # - name: Run Clippy
-      #   run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -W clippy::pedantic -D warnings
 
       - name: Check Rust formatting
         run: cargo fmt -- --check
+
+      - name: Run Rust tests
+        run: cargo test
 
       - name: Deploy Enclave
         env:


### PR DESCRIPTION
# Why
We need to parse out the PCRs from the enclave build, send them to the data service layer, and also print them as a job output.
We need to run tests in CI.
We should use clippy in pedantic mode for OS repos.

# How
It parses out the PCRs using `jq`. It the send them to the data service layer (this is commented out for now). It also prints the PCRs and version as a GitHub output summary.
It updates clippy to use pedantic mode and fixes any existing warnings
It adds `cargo test` to CI

# Security / Environment Variables (if applicable)
- adding `jq` but this is well supported.

# Testing
- see github actions output