### PR TITLE
silence curl happy path

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -107,12 +107,13 @@ jobs:
           # fail fast if any part of the pipe errors
           set -eo pipefail
           echo "Sending PCR JSON to data service…"
-          # fail on 4xx/5xx, show errors
-          curl --fail \
+          # -sS: silent but show errors; -f: fail on HTTP 4xx/5xx
+          curl -sS -f \
             -X POST "${{ env.YP_DS_API_URL }}" \
             -H "x-api-key: ${{ env.YP_DS_API_KEY }}" \
             -H "Content-Type: application/json" \
-            --data @pcrs.json
+            --data @pcrs.json \
+            > /dev/null
           echo "Uploaded to the YP Data Service"
 
       - name: Output PCRs & version in GitHub Step Summary


### PR DESCRIPTION
# Why
Silence the curl output during the "happy path" by updating the curl command.

# How
Updated curl options to use -sS and -f.
Added redirection of stdout to /dev/null while retaining error output on stderr.
Updated inline comments to reflect these changes.


- set -eo pipefail makes the step exit on any failure.
- curl -sS -f
   - s silences progress and body,
   - S still shows error messages on stderr,
   - f causes a non-zero exit on HTTP 4xx/5xx.
- Redirecting > /dev/null to drop any 2xx response body from logs