### PR TITLE
injects version to rust runtime

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -76,6 +76,7 @@ jobs:
           EV_APP_UUID: ${{ env.EV_APP_UUID }}
           EV_ENCLAVE_SIGNING_CERT: ${{ env.EV_ENCLAVE_SIGNING_CERT }}
           EV_ENCLAVE_SIGNING_KEY: ${{ env.EV_ENCLAVE_SIGNING_KEY }}
+          VERSION: ${{ env.VERSION }}
         run: |
           # fail fast if any part of the pipe errors
           set -eo pipefail
@@ -86,6 +87,7 @@ jobs:
           echo "$EV_ENCLAVE_SIGNING_KEY"  > key.pem
           # deploy and emit a compact pcr.json
           ev enclave deploy -v \
+            --build-arg VERSION=${{ env.VERSION }} \
             | tee raw.json \
             | jq -c \
                 --arg version ${{ env.VERSION }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN cargo build --release
 
 # --- Runtime Stage ---
 FROM debian:bookworm-slim
+
+# Expose VERSION to the container’s env
+ARG VERSION
+ENV VERSION=${VERSION}
+
 WORKDIR /app
 
 # Copy the built binary

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,11 @@ macro_rules! ok_or_internal_error {
 
 #[tokio::main]
 async fn main() {
+    // read VERSION from the environment, fallback to "unknown"
+    let version = std::env::var("VERSION").unwrap_or_else(|_| "unknown".to_string());
+
+    println!("Version: {}", version);
+
     // build our application with routes
     let app = Router::new().route("/prove", post(prove));
 


### PR DESCRIPTION
# Why
We need access to the `version` in the Rust runtime.

# How
Injects via ev deploy build arg, and further propagates in Dockerfile.

# Security / Environment Variables (if applicable)
The only concern here is if a malicious version is injected somehow.

# Testing
We will need to run the workflow e2e.

❓❓❓

@davidnugent2425 thoughts on parsing out the version in `main.rs` to make sure it's a version? I am using `semver = { version = "1.0.26", features = ["serde"] }` in the other rust apps for this but maybe it can be something lighter. Will leave to you when you tackle uploading the attestation doc to the DSL.