### PR TITLE
Add ability for server to upload attestation doc to data layer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,7 @@ async fn prove(Json(proof_request): Json<ProofRequest>, config: Config) -> Statu
 
     // Success path
     println!("All verifications completed successfully");
-    StatusCode::OK
+    StatusCode::NO_CONTENT
 }
 
 fn validate_inputs(
@@ -941,7 +941,7 @@ mod tests {
             },
         )
         .await;
-        assert_eq!(response, StatusCode::OK);
+        assert_eq!(response, StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Why
- We need to upload attestation docs (proofs) to data layer for permanence, and we must also include what version and addresses the proof corresponds to

# How
- Add `Config` struct which pulls in the version, data layer URL, and data layer API key env vars. It does a basic sanity check on each, to catch the cases where they are empty strings, or where env vars have been mis-entered. I intentionally made these sanity checks very basic, as I'm afraid that adding more complexity to them could result in false-negatives that block TEE deployments.
- Add `upload_to_data_layer` function. Errors in this function are returned as internal errors, because we expect all of this code to work.
- Small lint: made it explicit that the `prove` endpoint returns only a `StatusCode`. This was already the logic, but we previously had the return of that function as `impl IntoResponse`.

# Security / Environment Variables (if applicable)
- Expects environment variables: `VERSION`, `YP_DS_API_BASE_URL` and `YP_DS_API_KEY` to be present. The `VERSION` one is added at build time in our CI, and I've checked that the `YP_DS..` ones match the secrets in our Evervault Enclave dashboard.

# Testing
- Added a mock server for the data layer endpoint, so our end-to-end test can check that the data layer endpoint is hit with the correct data
- Added unit tests for our sanity check functions
