### PR TITLE
Use basic signed message format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -421,8 +421,7 @@ fn generate_expected_message(
     ml_dsa_address: &MlDsaAddress,
 ) -> String {
     format!(
-        "I want to permanently link my Bitcoin address {} with my post-quantum address {}",
-        bitcoin_address, ml_dsa_address
+        "I want to permanently link my Bitcoin address {bitcoin_address} with my post-quantum address {ml_dsa_address}"
     )
 }
 


### PR DESCRIPTION
# Why
- We're currently just verifying that both keypairs signed a hello world message. We need to ensure the message contains both addresses, to verify that they are linked.

# How
- Add `generate_signed_message` function, resulting in messages that look like: `I want to permanently link my Bitcoin address 1M36YGRbipdjJ8tjpwnhUS5Njo2ThBVpKm with my post-quantum address iJeO896MYWHt86o8JRfEGcl6fgInl3WxvTwI5VK1Gl4=`
- Add `expected_message` parameter to bitcoin and ml_dsa verification functions
- Any key design decisions or implementation details?

# Security / Environment Variables (if applicable)
- N/A

# Testing
- I made a [demo change](https://github.com/p-11/yellowpages-client/commit/64fbc3c994cfdb48812e34d5c9e6ee61b8729fdb) to our yellowpages-client to generate messages of that format, using our hardcoded mnemonic. I used this to generate new test data for our verification and end-to-end tests.
- Added a unit test for the message generation
- Noticed we didn't have a test for ml_dsa verification that runs against our hardcoded signature for backwards compatibility, so I added one for that. That would be caught in our end-to-end tests anyways, but still good to have a more specific one.

# Note
This should only be released once the frontend is updated to generate signatures of this format.