### PR TITLE
Add open CORS middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1892,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tokio",
+ "tower-http",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.22"
 bitcoin = "0.32.5"
 serde_json = "1.0"
 ml-dsa = "0.0.4"
+tower-http = { version = "0.6.2", features = ["cors"] }
 
 [dev-dependencies]
 rand = "0.9.1"


### PR DESCRIPTION
# Why
- We need to support CORS to allow browsers to hit the proof service. We'll keep it open for now.

# How
- Add tower-http for middleware. tower-http is required for doing middleware in axum: https://docs.rs/axum/latest/axum/middleware/index.html
- Add a CORS layer configured to allow POST requests from any domain, with headers support for content type (the only header required for the proof request), and the [three headers that may be in CORS preflights](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request)

# Security / Environment Variables (if applicable)
- Our server was already open, this allows browsers to hit them. We have a subsequent ticket for [locking down ingress](https://linear.app/projecteleven/issue/PRO-186/lock-down-tees-to-relevant-ingress-and-egress-environments-ipsdomains)
- Added [tower-http](https://crates.io/crates/tower-http) as a dependency at its latest version. It's a very popular crate, and mandatory for axum middleware.

# Testing
- I used a basic HTML+Javascript to reproduce the preflight error locally, and then validate that the preflight succeeds after these changes.
