### PR TITLE
ensures debug is set to false for production deployments

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -46,6 +46,13 @@ jobs:
             exit 1
           fi
 
+      - name: Abort if debug set to true
+        run: |
+          if [ "${{ env.EV_ENCLAVE_DEBUG }}" = "true" ]; then
+            echo "::error::This workflow must not be run with debug set to true."
+            exit 1
+          fi
+
       - name: Validate semver
         run: |
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
# Why
We don't want debug set to True in production deployments as we should have no access to transaction or application logs.

# How
Adds a guard step that aborts the job if `EV_ENCLAVE_DEBUG` is set to `true`

Note this we have hardcoded debug to `false` but nonetheless this extra guard may save our ass one day!
