### PR TITLE
Make turnstile validation happen earlier – on http upgrade

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2427,7 +2427,7 @@ mod tests {
         .await;
 
         // Connect to the WebSocket server with invalid turnstile token
-        let ws_url = format!("ws://127.0.0.1:8008/prove?cf_turnstile_token=invalid");
+        let ws_url = "ws://127.0.0.1:8008/prove?cf_turnstile_token=invalid".to_string();
         let connection_result = connect_async(ws_url).await;
 
         // The connection should fail with an HTTP error due to invalid turnstile token
@@ -2446,7 +2446,7 @@ mod tests {
                     "Should get 403 Forbidden status for invalid turnstile token"
                 );
             }
-            _ => panic!("Expected HTTP error, got: {:?}", error),
+            _ => panic!("Expected HTTP error, got: {error:?}"),
         }
     }
 
@@ -2462,7 +2462,7 @@ mod tests {
         .await;
 
         // Connect to the WebSocket server with invalid turnstile token
-        let ws_url = format!("ws://127.0.0.1:8008/prove");
+        let ws_url = "ws://127.0.0.1:8008/prove".to_string();
         let connection_result = connect_async(ws_url).await;
 
         // The connection should fail with an HTTP error due to invalid turnstile token
@@ -2481,7 +2481,7 @@ mod tests {
                     "Should get 400 Bad Request status for invalid turnstile token"
                 );
             }
-            _ => panic!("Expected HTTP error, got: {:?}", error),
+            _ => panic!("Expected HTTP error, got: {error:?}"),
         }
     }
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -101,12 +101,9 @@ pub async fn handle_ws_upgrade(
     log::info!("Received WebSocket upgrade request");
 
     // Extract and validate Turnstile token from query parameters
-    let turnstile_token = match params.get("cf_turnstile_token") {
-        Some(token) => token,
-        None => {
-            log::error!("Missing turnstile_token query parameter");
-            return HttpStatusCode::BAD_REQUEST.into_response();
-        }
+    let Some(turnstile_token) = params.get("cf_turnstile_token") else {
+        log::error!("Missing turnstile_token query parameter");
+        return HttpStatusCode::BAD_REQUEST.into_response();
     };
 
     // Check Turnstile token length


### PR DESCRIPTION
# Why
- If we validate the token earlier, then we won't have our server doing unauthorized waits for the first handshake message

# How
- Expect a `cf_turnstile_token` url param on HTTP WS Upgrade requests, validate it before going into our WS handler
- Revert `perform_handshake` function to no longer do token validation
- Update validation function to return HTTP err codes

# Security / Environment Variables (if applicable)
- N/A

# Testing
- Updated e2e tests to use turnstile URL param. Also fixed the port that those run on, so I can use deterministic URLs in my e2e tests that try invalid URL params.
- Updated unit tests to expect HTTP responses
- Tested using WIP frontend PR
