### PR TITLE
Run server as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,18 @@ ENV VERSION=${VERSION}
 
 WORKDIR /app
 
+# Create a non-root user and group.
+# Note: Evervault’s entry-point will run `su app -c 'exec /usr/local/bin/yellowpages-proof-service'`.
+# `su` refuses to switch to a user whose login shell is “nologin” or “false”.
+# We therefore create `app` with a real shell (`/bin/sh`) so the `su` call succeeds.
+RUN addgroup --system app && adduser --system --ingroup app --shell /bin/sh app
+
 # Copy the built binary
 COPY --from=builder /app/target/release/yellowpages-proof-service /usr/local/bin/yellowpages-proof-service
+
+# Change ownership and switch to non-root user.
+RUN chown -R app:app /usr/local/bin/yellowpages-proof-service
+USER app
 
 # Expose the port (matches our server's port)
 EXPOSE 8008


### PR DESCRIPTION
# Why
- Although the attack surface is smaller in Nitro Enclaves, it's still better practice to run our server as a non-root user

# How
- Use the same standard user configuration we do in other services (https://github.com/p-11/yellowpages-verification-service/blob/79302565a9f95f5b28a08f68047a6ca5d4645e37/Dockerfile#L14-L22), with one change: add `--shell /bin/sh`, along with the comment:
```
# Note: Evervault’s entry-point will run `su app -c 'exec /usr/local/bin/yellowpages-proof-service'`.
# `su` refuses to switch to a user whose login shell is “nologin” or “false”.
# We therefore create `app` with a real shell (`/bin/sh`) so the `su` call succeeds.
```


# Security / Environment Variables (if applicable)
- Security improvement, as we are no longer running the server as the root user

# Testing
- Tried it out using a separate POC Enclave
- Began an `ev enclave build` locally, using a dummy `enclave.toml`, so I could inspect the generated `enclave.Dockerfile`, to validate that it now does `su app -c 'exec /usr/local/bin/yellowpages-proof-service'`. Here's the full `enclave.Dockerfile` for reference, it's interesting to see:
```
#  --- Build Stage ---
FROM rust:1.86 AS builder
WORKDIR /app
#  Copy manifest and source code.
COPY Cargo.toml Cargo.lock ./
COPY src ./src
#  Build the application in release mode.
RUN cargo build --release
#  --- Runtime Stage ---
FROM debian:bookworm-slim AS lastlayer
#  Expose VERSION to the container’s env
ARG VERSION
ENV VERSION=${VERSION}
WORKDIR /app
#  Create a non-root user and group.
#  Note: Evervault’s entry-point will run `su app -c 'exec /usr/local/bin/yellowpages-proof-service'`.
#  `su` refuses to switch to a user whose login shell is “nologin” or “false”.
#  We therefore create `app` with a real shell (`/bin/sh`) so the `su` call succeeds.
RUN addgroup --system app && adduser --system --ingroup app --shell /bin/sh app
#  Copy the built binary
COPY --from=builder /app/target/release/yellowpages-proof-service /usr/local/bin/yellowpages-proof-service
#  Change ownership and switch to non-root user.
RUN chown -R app:app /usr/local/bin/yellowpages-proof-service
USER app
#  Expose the port (matches our server's port)
#  Run the binary using absolute path
USER root
RUN mkdir -p /opt/evervault
ADD https://enclave-build-assets.evervault.com/installer/173cb7030ebc30708c6c98266d15dba12f0265d3e7da3f66bb7cc5c3c4dbf94f.tar.gz /opt/evervault/runtime-dependencies.tar.gz
RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
RUN echo {\"api_key_auth\":false,\"egress\":{\"allow_list\":\"ds.api.url.fake,challenges.cloudflare.com\"},\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":null,\"healthcheck_use_tls\":false,\"trusted_headers\":[],\"trx_logging_enabled\":false} > /etc/dataplane-config.json
RUN mkdir -p /etc/service/user-entrypoint
RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nsu app -c 'exec /usr/local/bin/yellowpages-proof-service'\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
ADD https://enclave-build-assets.evervault.com/runtime/1.3.2/data-plane/egress-enabled/tls-termination-enabled /opt/evervault/data-plane
RUN chmod +x /opt/evervault/data-plane
RUN mkdir -p /etc/service/data-plane
RUN printf "#!/bin/sh\necho \"Booting Evervault data plane...\"\nexec /opt/evervault/data-plane 8008\n" > /etc/service/data-plane/run && chmod +x /etc/service/data-plane/run
RUN printf "#!/bin/sh\nifconfig lo 127.0.0.1\n echo \"enclave.local\" > /etc/hostname \n echo \"127.0.0.1 enclave.local\" >> /etc/hosts \n hostname -F /etc/hostname \niptables -A OUTPUT -t nat -p tcp --dport 1:65535 ! -d 127.0.0.1  -j DNAT --to-destination 127.0.0.1:4444\nip route add default via 127.0.0.1 dev lo\niptables -t nat -A POSTROUTING -o lo -s 0.0.0.0 -j SNAT --to-source 127.0.0.1\necho \"Booting enclave...\"\nexec runsvdir /etc/service\n" > /bootstrap && chmod +x /bootstrap
ENTRYPOINT ["/bootstrap", "1>&2"]
```
