### PR TITLE
CI fix: P11-02-002 WP3: Lack of commit pinning in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Ensure Clippy is available
         run: rustup component add clippy

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -55,7 +55,7 @@ jobs:
           echo "Version is valid: $VERSION"
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Render config.toml
         env:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Version is valid: $VERSION"
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Render config.toml
         env:


### PR DESCRIPTION
# Why
"""
During the review of GitHub Actions workflows across all repositories, it was found that third-party actions were pinned to a version tag and not a specific commit. While pinning by version tag is a common practice, using the full commit SHA provides additional protection against supply chain attacks, as it directly references a unique point in the
Git history.
Affected file:
yellowpages-data-layer-service/.github/workflows/deploy_prod.yml
Affected code:
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
- name: Configure AWS credentials
  uses: aws-actions/configure-aws-credentials@v4
"""

# How
"While the third-party actions present in the analyzed workflows are maintained by established actors, it is recommended to consider introducing commit pinning as an additional defense-in-depth measure against potential supply chain attacks."
- For every instance of `uses:` in the repo, I checked the releases for the relevant Action, and copied over the commit of the latest release.
  - https://github.com/actions/checkout/releases/tag/v4.2.2

# Security / Environment Variables (if applicable)
- Fixes P11-02-002 WP3: Lack of commit pinning in GitHub Actions

# Testing
- CI on this PR should succeed
