### PR TITLE
updates GLOBAL_RATE_LIMIT_REQS_PER_MIN

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use tower::{ServiceBuilder, buffer::BufferLayer, limit::RateLimitLayer, load_she
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 use utils::{RightmostXForwardedForIpExtractor, validate_cloudflare_turnstile_token};
 
-const GLOBAL_RATE_LIMIT_REQS_PER_MIN: u64 = 1_000; // 1,000 requests per minute
+const GLOBAL_RATE_LIMIT_REQS_PER_MIN: u64 = 300; // 300 requests per minute
 // A Turnstile token can have up to 2048 characters: https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
 const MAX_TURNSTILE_TOKEN_LENGTH: usize = 2048;
 


### PR DESCRIPTION
# Why
•  Reduce the risk of registry spam during distributed attacks or extended periods where the eng team is offline.
•  Currently, the 1,000 requests/minute global limit allows attackers to register up to 360,000 entries during a 6-hour offline period
•  With minimal genuine yellowpages usage currently, we can afford to be more restrictive to improve security posture

# How
•  Reduced `GLOBAL_RATE_LIMIT_REQS_PER_MIN` constant from 1,000 to 300 requests per minute
•  This 70% reduction limits potential spam to 108,000 registrations during a 6-hour period (down from 360,000)
•  Maintains reasonable capacity at 5 requests/second average for legitimate usage
•  Per-IP limits (3 requests per 5 minutes in production) remain unchanged and will continue to be the first line of defense

# Security / Environment Variables (if applicable)
•  This change improves security by significantly reducing the attack surface for registry spam
•  No new environment variables required
•  No additional setup needed - change takes effect immediately upon deployment
•  The layered rate limiting approach ensures per-IP limits (0.6 req/min/IP) trigger before global limits

# Testing
•  Verified that per-IP rate limiting remains the primary defense mechanism
•  Confirmed that global limit reduction maintains sufficient capacity for current usage patterns
•  No breaking changes to existing functionality
