### PR TITLE
update flow to build -> upload PCRs -> deploy

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -99,7 +99,7 @@ jobs:
               exit 1
           fi
 
-      - name: Deploy Enclave
+      - name: Build Enclave
         env:
           EV_API_KEY: ${{ env.EV_API_KEY }}
           EV_APP_UUID: ${{ env.EV_APP_UUID }}
@@ -114,10 +114,15 @@ jobs:
           # write cert + key
           echo "$EV_ENCLAVE_SIGNING_CERT" > cert.pem
           echo "$EV_ENCLAVE_SIGNING_KEY"  > key.pem
-          # deploy and emit a compact pcr.json
-          ev enclave deploy -v \
+          # create output directory for build artifacts
+          mkdir -p ./build-output
+          # build enclave and emit a compact pcr.json
+          ev enclave build -v \
             --build-arg VERSION=${{ env.VERSION }} \
             --config=./enclave.toml \
+            --output=./build-output \
+            --signing-cert=cert.pem \
+            --private-key=key.pem \
             | tee raw.json \
             | jq -c \
                 --arg version ${{ env.VERSION }} \
@@ -140,6 +145,7 @@ jobs:
           set -eo pipefail
           echo "Sending PCR JSON to data service…"
           # -sS: silent but show errors; -f: fail on HTTP 4xx/5xx
+          # The data layer will return an error if the version already exists, causing the workflow to fail
           curl -sS -f \
             -X POST "https://${{ env.YP_DS_API_URL }}/v1/proofs/measurements/aws-nitro-pcr-sets" \
             -H "x-api-key: ${{ env.YP_DS_API_KEY }}" \
@@ -147,6 +153,25 @@ jobs:
             --data @pcrs.json \
             > /dev/null
           echo "Uploaded to the YP Data Service"
+
+      - name: Deploy Enclave
+        env:
+          EV_API_KEY: ${{ env.EV_API_KEY }}
+          EV_APP_UUID: ${{ env.EV_APP_UUID }}
+          EV_ENCLAVE_SIGNING_CERT: ${{ env.EV_ENCLAVE_SIGNING_CERT }}
+          EV_ENCLAVE_SIGNING_KEY: ${{ env.EV_ENCLAVE_SIGNING_KEY }}
+        run: |
+          # fail fast if any part of the pipe errors
+          set -eo pipefail
+          # write cert + key
+          echo "$EV_ENCLAVE_SIGNING_CERT" > cert.pem
+          echo "$EV_ENCLAVE_SIGNING_KEY"  > key.pem
+          # deploy the previously built enclave using the EIF file
+          ev enclave deploy \
+            --config=./enclave.toml \
+            --eif-path=./build-output/enclave.eif \
+            --signing-cert=cert.pem \
+            --private-key=key.pem
 
       - name: Output PCRs & version in GitHub Step Summary
         run: |

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -106,7 +106,7 @@ jobs:
               exit 1
           fi
 
-      - name: Deploy Enclave
+      - name: Build Enclave
         env:
           EV_API_KEY: ${{ env.EV_API_KEY }}
           EV_APP_UUID: ${{ env.EV_APP_UUID }}
@@ -121,10 +121,15 @@ jobs:
           # write cert + key
           echo "$EV_ENCLAVE_SIGNING_CERT" > cert.pem
           echo "$EV_ENCLAVE_SIGNING_KEY"  > key.pem
-          # deploy and emit a compact pcr.json
-          ev enclave deploy -v \
+          # create output directory for build artifacts
+          mkdir -p ./build-output
+          # build enclave and emit a compact pcr.json
+          ev enclave build -v \
             --build-arg VERSION=${{ env.VERSION }} \
             --config=./enclave.toml \
+            --output=./build-output \
+            --signing-cert=cert.pem \
+            --private-key=key.pem \
             | tee raw.json \
             | jq -c \
                 --arg version ${{ env.VERSION }} \
@@ -147,6 +152,7 @@ jobs:
           set -eo pipefail
           echo "Sending PCR JSON to data service…"
           # -sS: silent but show errors; -f: fail on HTTP 4xx/5xx
+          # The data layer will return an error if the version already exists, causing the workflow to fail
           curl -sS -f \
             -X POST "https://${{ env.YP_DS_API_URL }}/v1/proofs/measurements/aws-nitro-pcr-sets" \
             -H "x-api-key: ${{ env.YP_DS_API_KEY }}" \
@@ -154,6 +160,25 @@ jobs:
             --data @pcrs.json \
             > /dev/null
           echo "Uploaded to the YP Data Service"
+
+      - name: Deploy Enclave
+        env:
+          EV_API_KEY: ${{ env.EV_API_KEY }}
+          EV_APP_UUID: ${{ env.EV_APP_UUID }}
+          EV_ENCLAVE_SIGNING_CERT: ${{ env.EV_ENCLAVE_SIGNING_CERT }}
+          EV_ENCLAVE_SIGNING_KEY: ${{ env.EV_ENCLAVE_SIGNING_KEY }}
+        run: |
+          # fail fast if any part of the pipe errors
+          set -eo pipefail
+          # write cert + key
+          echo "$EV_ENCLAVE_SIGNING_CERT" > cert.pem
+          echo "$EV_ENCLAVE_SIGNING_KEY"  > key.pem
+          # deploy the previously built enclave using the EIF file
+          ev enclave deploy \
+            --config=./enclave.toml \
+            --eif-path=./build-output/enclave.eif \
+            --signing-cert=cert.pem \
+            --private-key=key.pem
 
       - name: Output PCRs & version in GitHub Step Summary
         run: |


### PR DESCRIPTION
# Why
- Fix race condition in enclave deployment where users could create proof requests between when an enclave deployment finishes and when PCR measurements are uploaded to the data layer
- This race condition could result in users attempting to create proofs against an enclave version that doesn't yet exist in the data layer
- Ensure workflows fail if they attempt to upload duplicate version+PCRs pairs to prevent data inconsistency

# How
- Split the "Deploy Enclave" step into separate "Build Enclave" and "Deploy Enclave" steps in both dev and prod workflows
- Moved PCR measurements upload step to occur between build and deploy, ensuring measurements are available before the enclave goes live
- Updated build step to use ev enclave build with --output parameter to generate EIF file and extract PCR measurements
- Updated deploy step to use ev enclave deploy with --eif-path parameter to deploy the pre-built EIF
- Both build and deploy steps maintain proper signing certificate and private key configuration
-
# Security / Environment Variables (if applicable)
- nil

# Testing
- will be best to test on dev deployment
