### PR TITLE
Add new response code for insufficient BTC balance

### DIFF
--- a/src/pq_channel.rs
+++ b/src/pq_channel.rs
@@ -35,6 +35,7 @@ const PROOF_REQUEST_TIMEOUT_SECS: u64 = 30; // 30 seconds for proof submission
 // Custom close code in the private range 4000-4999
 const TIMEOUT_CLOSE_CODE: u16 = 4000; // Custom code for timeout errors
 pub const MAX_REGISTRATIONS_EXCEEDED: u16 = 4001; // Custom close code for max registrations exceeded
+pub const INSUFFICIENT_BTC_BALANCE: u16 = 4002; // Custom close code for insufficient BTC balance
 
 // Constants for AES-GCM
 pub const AES_GCM_NONCE_LENGTH: usize = 12; // length in bytes


### PR DESCRIPTION
# Why
- The data layer will respond with a 400 with the text "Bitcoin address has insufficient balance" if the Bitcoin address is an empty wallet, as a spam mitigation. We need to handle this response and transmit a specific response code back to the frontend.

# How
- Add `4002` WS response code for insufficient BTC balance.
- Return this response code if the expected response is received from the data layer.

# Security / Environment Variables (if applicable)
- N/A

# Testing
- Added test that this flow will result in the expected WS response code
